### PR TITLE
Fix prefix handling

### DIFF
--- a/caddy/README.md
+++ b/caddy/README.md
@@ -4,6 +4,8 @@ Login plugin for caddy, based on [tarent/loginsrv](https://github.com/tarent/log
 The login is checked against a backend and then returned as JWT token.
 This middleware is designed to play together with the [caddy-jwt](https://github.com/BTBurke/caddy-jwt) plugin.
 
+For a full documentation of loginsrv configuration and usage, visit the [loginsrv README.md](https://github.com/tarent/loginsrv).
+
 ## Configuration
 To be compatible with caddy-jwt, the jwt secret is taken from the enviroment variable `JWT_SECRET`
 if such a variable is set. Otherwise, a random token is generated and set as enviroment variable JWT_SECRET,
@@ -20,9 +22,9 @@ login / {
 ### Full configuration example
 ```
 login / {
-    success-url /after/login
-    cookie-name alternativeName
-    cookie-http-only true
+    success_url /after/login
+    cookie_name alternativeName
+    cookie_http_only true
     simple bob=secret
     osiam endpoint=http://localhost:8080,client_id=example-client,client_secret=secret
     htpasswd file=users

--- a/caddy/handler.go
+++ b/caddy/handler.go
@@ -5,21 +5,18 @@ import (
 	"github.com/tarent/loginsrv/login"
 	_ "github.com/tarent/loginsrv/osiam"
 	"net/http"
-	"path"
 	"strings"
 )
 
 type CaddyHandler struct {
 	next         httpserver.Handler
-	path         string
 	config       *login.Config
 	loginHandler *login.Handler
 }
 
-func NewCaddyHandler(next httpserver.Handler, path string, loginHandler *login.Handler, config *login.Config) *CaddyHandler {
+func NewCaddyHandler(next httpserver.Handler, loginHandler *login.Handler, config *login.Config) *CaddyHandler {
 	h := &CaddyHandler{
 		next:         next,
-		path:         path,
 		config:       config,
 		loginHandler: loginHandler,
 	}
@@ -27,7 +24,7 @@ func NewCaddyHandler(next httpserver.Handler, path string, loginHandler *login.H
 }
 
 func (h *CaddyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
-	if strings.HasPrefix(r.URL.Path, path.Join(h.path, "/login")) {
+	if strings.HasPrefix(r.URL.Path, h.config.LoginPath) {
 		h.loginHandler.ServeHTTP(w, r)
 		return 0, nil
 	} else {

--- a/caddy/setup.go
+++ b/caddy/setup.go
@@ -18,7 +18,6 @@ func init() {
 		ServerType: "http",
 		Action:     setup,
 	})
-	httpserver.RegisterDevDirective("login", "jwt")
 }
 
 // setup configures a new loginsrv instance.

--- a/caddy/setup.go
+++ b/caddy/setup.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/tarent/loginsrv/oauth2"
 	_ "github.com/tarent/loginsrv/osiam"
 	"os"
+	"strings"
 )
 
 func init() {
@@ -69,7 +70,10 @@ func parseConfig(c *caddy.Controller) (*login.Config, error) {
 	cfg.ConfigureFlagSet(fs)
 
 	for c.NextBlock() {
-		name := c.Val()
+		// caddy preferes '_' in parameter names,
+		// so we map them to the '-' from the command line flags
+		// the replacement supports both, for backwards compatibility
+		name := strings.Replace(c.Val(), "_", "-", -1)
 		args := c.RemainingArgs()
 		if len(args) != 1 {
 			return cfg, fmt.Errorf("Wrong number of arguments for %v: %v (%v:%v)", name, args, c.File(), c.Line())

--- a/caddy/setup.go
+++ b/caddy/setup.go
@@ -35,7 +35,7 @@ func setup(c *caddy.Controller) error {
 
 		if len(args) == 1 {
 			logging.Logger.Warnf("DEPRECATED: Please set the loing path by parameter login_path and not as directive argument (%v:%v)", c.File(), c.Line())
-			config.LoginPath = args[0]
+			config.LoginPath = args[0] + "/login"
 		}
 
 		if e, isset := os.LookupEnv("JWT_SECRET"); isset {

--- a/caddy/setup.go
+++ b/caddy/setup.go
@@ -34,7 +34,7 @@ func setup(c *caddy.Controller) error {
 		}
 
 		if len(args) == 1 {
-			logging.Logger.Warn("DEPRECATED: Please set the loing path by parameter login_path and not as directive argument (%v:%v)", c.File(), c.Line())
+			logging.Logger.Warnf("DEPRECATED: Please set the loing path by parameter login_path and not as directive argument (%v:%v)", c.File(), c.Line())
 			config.LoginPath = args[0]
 		}
 

--- a/caddy/setup.go
+++ b/caddy/setup.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/tarent/loginsrv/oauth2"
 	_ "github.com/tarent/loginsrv/osiam"
 	"os"
+	"path"
 	"strings"
 )
 
@@ -35,7 +36,7 @@ func setup(c *caddy.Controller) error {
 
 		if len(args) == 1 {
 			logging.Logger.Warnf("DEPRECATED: Please set the loing path by parameter login_path and not as directive argument (%v:%v)", c.File(), c.Line())
-			config.LoginPath = args[0] + "/login"
+			config.LoginPath = path.Join(args[0], "/login")
 		}
 
 		if e, isset := os.LookupEnv("JWT_SECRET"); isset {

--- a/caddy/setup_test.go
+++ b/caddy/setup_test.go
@@ -68,7 +68,7 @@ func TestSetup(t *testing.T) {
 			// * login path as argument
 			// * '-' in parameter names
 			// * backend config by 'backend provider='
-			input: `loginsrv /foo {
+			input: `loginsrv /context {
                                         backend provider=simple,bob=secret
                                         cookie-name cookiename
                                 }`,
@@ -76,7 +76,7 @@ func TestSetup(t *testing.T) {
 			config: login.Config{
 				JwtSecret:      "jwtsecret",
 				SuccessUrl:     "/",
-				LoginPath:      "/foo",
+				LoginPath:      "/context/login",
 				CookieName:     "cookiename",
 				CookieHttpOnly: true,
 				Backends: login.Options{

--- a/caddy/setup_test.go
+++ b/caddy/setup_test.go
@@ -86,6 +86,28 @@ func TestSetup(t *testing.T) {
 				},
 				Oauth: login.Options{},
 			}},
+		{ // backwards compatibility
+			// * login path as argument
+			// * '-' in parameter names
+			// * backend config by 'backend provider='
+			input: `loginsrv / {
+                                        backend provider=simple,bob=secret
+                                        cookie-name cookiename
+                                }`,
+			shouldErr: false,
+			config: login.Config{
+				JwtSecret:      "jwtsecret",
+				SuccessUrl:     "/",
+				LoginPath:      "/login",
+				CookieName:     "cookiename",
+				CookieHttpOnly: true,
+				Backends: login.Options{
+					"simple": map[string]string{
+						"bob": "secret",
+					},
+				},
+				Oauth: login.Options{},
+			}},
 
 		// error cases
 		{input: "loginsrv {\n}", shouldErr: true},

--- a/caddy/setup_test.go
+++ b/caddy/setup_test.go
@@ -21,7 +21,7 @@ func TestSetup(t *testing.T) {
 	}{
 		{ //defaults
 			input: `loginsrv / {
-                                        backend provider=simple,bob=secret
+                                        simple bob=secret
                                 }`,
 			shouldErr: false,
 			path:      "/",
@@ -39,11 +39,11 @@ func TestSetup(t *testing.T) {
 			}},
 		{
 			input: `loginsrv / {
-                                        success-url successurl
-                                        cookie-name cookiename
-                                        cookie-http-only false
-                                        backend provider=simple,bob=secret
-                                        backend provider=osiam,endpoint=http://localhost:8080,clientId=example-client,clientSecret=secret
+                                        success_url successurl
+                                        cookie_name cookiename
+                                        cookie_http_only false
+                                        simple bob=secret
+                                        osiam endpoint=http://localhost:8080,client_id=example-client,client_secret=secret
                                 }`,
 			shouldErr: false,
 			path:      "/",
@@ -57,9 +57,9 @@ func TestSetup(t *testing.T) {
 						"bob": "secret",
 					},
 					"osiam": map[string]string{
-						"endpoint":     "http://localhost:8080",
-						"clientId":     "example-client",
-						"clientSecret": "secret",
+						"endpoint":      "http://localhost:8080",
+						"client_id":     "example-client",
+						"client_secret": "secret",
 					},
 				},
 				Oauth: login.Options{},
@@ -67,8 +67,8 @@ func TestSetup(t *testing.T) {
 		// error cases
 		{input: "loginsrv {\n}", shouldErr: true},
 		{input: "loginsrv xx yy {\n}", shouldErr: true},
-		{input: "loginsrv / {\n cookie-http-only 42 \n backend provider=simple,bob=secret \n}", shouldErr: true},
-		{input: "loginsrv / {\n unknown property \n backend provider=simple,bob=secret \n}", shouldErr: true},
+		{input: "loginsrv / {\n cookie_http_only 42 \n simple bob=secret \n}", shouldErr: true},
+		{input: "loginsrv / {\n unknown property \n simple bob=secret \n}", shouldErr: true},
 		{input: "loginsrv / {\n backend \n}", shouldErr: true},
 		{input: "loginsrv / {\n backend provider=foo\n}", shouldErr: true},
 		{input: "loginsrv / {\n backend kk\n}", shouldErr: true},

--- a/login/config.go
+++ b/login/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/tarent/lib-compose/logging"
 	"github.com/tarent/loginsrv/oauth2"
 	"math/rand"
 	"os"
@@ -25,6 +26,7 @@ func DefaultConfig() *Config {
 		LogLevel:       "info",
 		JwtSecret:      jwtDefaultSecret,
 		SuccessUrl:     "/",
+		LoginPath:      "/login",
 		CookieName:     "jwt_token",
 		CookieHttpOnly: true,
 		Backends:       Options{},
@@ -41,6 +43,7 @@ type Config struct {
 	TextLogging    bool
 	JwtSecret      string
 	SuccessUrl     string
+	LoginPath      string
 	CookieName     string
 	CookieHttpOnly bool
 	Backends       Options
@@ -83,9 +86,11 @@ func (c *Config) ConfigureFlagSet(f *flag.FlagSet) {
 	f.StringVar(&c.CookieName, "cookie-name", c.CookieName, "The name of the jwt cookie")
 	f.BoolVar(&c.CookieHttpOnly, "cookie-http-only", c.CookieHttpOnly, "Set the cookie with the http only flag")
 	f.StringVar(&c.SuccessUrl, "success-url", c.SuccessUrl, "The url to redirect after login")
+	f.StringVar(&c.LoginPath, "login-path", c.LoginPath, "The path of the login resource")
 
 	// the -backends is deprecated, but we support it for backwards compatibility
 	deprecatedBackends := setFunc(func(optsKvList string) error {
+		logging.Logger.Warn("DEPRECATED: '-backend' is no loger supported. Please set the backends by explicit paramters")
 		opts, err := parseOptions(optsKvList)
 		if err != nil {
 			return err

--- a/login/config_test.go
+++ b/login/config_test.go
@@ -26,6 +26,7 @@ func TestConfig_ReadConfig(t *testing.T) {
 		"--text-logging=true",
 		"--jwt-secret=jwtsecret",
 		"--success-url=successurl",
+		"--login-path=loginpath",
 		"--cookie-name=cookiename",
 		"--cookie-http-only=false",
 		"--backend=provider=simple",
@@ -40,6 +41,7 @@ func TestConfig_ReadConfig(t *testing.T) {
 		TextLogging:    true,
 		JwtSecret:      "jwtsecret",
 		SuccessUrl:     "successurl",
+		LoginPath:      "loginpath",
 		CookieName:     "cookiename",
 		CookieHttpOnly: false,
 		Backends: Options{
@@ -66,6 +68,7 @@ func TestConfig_ReadConfigFromEnv(t *testing.T) {
 	assert.NoError(t, os.Setenv("LOGINSRV_TEXT_LOGGING", "true"))
 	assert.NoError(t, os.Setenv("LOGINSRV_JWT_SECRET", "jwtsecret"))
 	assert.NoError(t, os.Setenv("LOGINSRV_SUCCESS_URL", "successurl"))
+	assert.NoError(t, os.Setenv("LOGINSRV_LOGIN_PATH", "loginpath"))
 	assert.NoError(t, os.Setenv("LOGINSRV_COOKIE_NAME", "cookiename"))
 	assert.NoError(t, os.Setenv("LOGINSRV_COOKIE_HTTP_ONLY", "false"))
 	assert.NoError(t, os.Setenv("LOGINSRV_SIMPLE", "foo=bar"))
@@ -78,6 +81,7 @@ func TestConfig_ReadConfigFromEnv(t *testing.T) {
 		TextLogging:    true,
 		JwtSecret:      "jwtsecret",
 		SuccessUrl:     "successurl",
+		LoginPath:      "loginpath",
 		CookieName:     "cookiename",
 		CookieHttpOnly: false,
 		Backends: Options{

--- a/login/handler_test.go
+++ b/login/handler_test.go
@@ -63,14 +63,24 @@ func TestHandler_NewFromConfig(t *testing.T) {
 
 func TestHandler_LoginForm(t *testing.T) {
 	recorder := call(req("GET", "/context/login", ""))
-	assert.Equal(t, recorder.Code, 200)
+	assert.Equal(t, 200, recorder.Code)
 	assert.Contains(t, recorder.Body.String(), `class="container`)
 	assert.Equal(t, "no-cache, no-store, must-revalidate", recorder.Header().Get("Cache-Control"))
 }
 
 func TestHandler_HEAD(t *testing.T) {
 	recorder := call(req("HEAD", "/context/login", ""))
-	assert.Equal(t, recorder.Code, 400)
+	assert.Equal(t, 400, recorder.Code)
+}
+
+func TestHandler_404(t *testing.T) {
+	recorder := call(req("GET", "/context/", ""))
+	assert.Equal(t, 404, recorder.Code)
+
+	recorder = call(req("GET", "/", ""))
+	assert.Equal(t, 404, recorder.Code)
+
+	assert.Equal(t, "Not Found: The requested page does not exist", recorder.Body.String())
 }
 
 func TestHandler_LoginJson(t *testing.T) {
@@ -201,22 +211,26 @@ func TestHandler_getToken_InvalidNoToken(t *testing.T) {
 }
 
 func testHandler() *Handler {
+	cfg := DefaultConfig()
+	cfg.LoginPath = "/context/login"
 	return &Handler{
 		backends: []Backend{
 			NewSimpleBackend(map[string]string{"bob": "secret"}),
 		},
 		oauth:  oauth2.NewManager(),
-		config: DefaultConfig(),
+		config: cfg,
 	}
 }
 
 func testHandlerWithError() *Handler {
+	cfg := DefaultConfig()
+	cfg.LoginPath = "/context/login"
 	return &Handler{
 		backends: []Backend{
 			errorTestBackend("test error"),
 		},
 		oauth:  oauth2.NewManager(),
-		config: DefaultConfig(),
+		config: cfg,
 	}
 }
 

--- a/login/login_form.go
+++ b/login/login_form.go
@@ -66,13 +66,12 @@ const loginForm = `<!DOCTYPE html>
                 <br/>
                 {{if .Picture}}<img class="login-picture" src="{{.Picture}}?s=120">{{end}}
                 {{if .Name}}<h3>{{.Name}}</h3>{{end}}
-                <br/>
-                <a class="btn btn-md btn-primary" href="login?logout=true">Logout</a>
               {{end}}
+                <br/>
+                <a class="btn btn-md btn-primary" href="{{ .Config.LoginPath }}?logout=true">Logout</a>
             {{else}}
-
               {{ range $providerName, $opts := .Config.Oauth }}
-                <a class="btn btn-block btn-lg btn-social btn-{{ $providerName }}" href="login/{{ $providerName }}">
+                <a class="btn btn-block btn-lg btn-social btn-{{ $providerName }}" href="{{ $.Config.LoginPath }}/{{ $providerName }}">
                   <span class="fa fa-{{ $providerName }}"></span> Sign in with {{ $providerName | ucfirst }}
                 </a>
               {{end}}
@@ -93,7 +92,7 @@ const loginForm = `<!DOCTYPE html>
 		    </div>
 	          </div>
 	          <div class="panel-body">
-		    <form accept-charset="UTF-8" role="form" method="POST" action="{{.Path}}">
+		    <form accept-charset="UTF-8" role="form" method="POST" action="{{.Config.LoginPath}}">
                       <fieldset>
 		        <div class="form-group">
 		          <input class="form-control" placeholder="Username" name="username" value="{{.UserInfo.Sub}}" type="text">
@@ -116,7 +115,6 @@ const loginForm = `<!DOCTYPE html>
 </html>`
 
 type loginFormData struct {
-	Path          string
 	Error         bool
 	Failure       bool
 	Config        *Config

--- a/main_test.go
+++ b/main_test.go
@@ -24,7 +24,7 @@ func Test_BasicEndToEnd(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// success
-	req, err := http.NewRequest("POST", "http://localhost:3000/context/login", strings.NewReader(`{"username": "bob", "password": "secret"}`))
+	req, err := http.NewRequest("POST", "http://localhost:3000/login", strings.NewReader(`{"username": "bob", "password": "secret"}`))
 	assert.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/jwt")

--- a/oauth2/manager.go
+++ b/oauth2/manager.go
@@ -87,6 +87,7 @@ func (manager *Manager) getConfigNameFromPath(path string) string {
 // Add a configuration for a provider
 func (manager *Manager) AddConfig(providerName string, opts map[string]string) error {
 	p, exist := GetProvider(providerName)
+
 	if !exist {
 		return fmt.Errorf("no provider for name %v", providerName)
 	}


### PR DESCRIPTION
Changed the prefix handling to the parameter login-path (login_path in caddy), as mentioned in #3.
And fixed the path handling in the form template.
