### PR TITLE
Caddy - Use {user} placeholder for logs #32

### DIFF
--- a/caddy/handler.go
+++ b/caddy/handler.go
@@ -25,9 +25,17 @@ func NewCaddyHandler(next httpserver.Handler, loginHandler *login.Handler, confi
 }
 
 func (h *CaddyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
+	//Fetch jwt token. If valid set a Caddy replacer for {user}
+	userInfo, valid := h.loginHandler.GetToken(r)
+	if valid {
+		repl := httpserver.NewReplacer(r, nil, "-")
+		repl.Set("user", userInfo.Sub)
+	}
+
 	if strings.HasPrefix(r.URL.Path, h.config.LoginPath) {
 		h.loginHandler.ServeHTTP(w, r)
 		return 0, nil
 	}
+		
 	return h.next.ServeHTTP(w, r)
 }

--- a/caddy/handler.go
+++ b/caddy/handler.go
@@ -36,6 +36,6 @@ func (h *CaddyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, e
 		h.loginHandler.ServeHTTP(w, r)
 		return 0, nil
 	}
-		
+
 	return h.next.ServeHTTP(w, r)
 }

--- a/caddy/handler_test.go
+++ b/caddy/handler_test.go
@@ -47,8 +47,16 @@ func Test_ServeHTTP_200(t *testing.T) {
 	}
 	
 	//Set cookie for user token on the ServeHTTP http.ResponseWriter
-	cookie := http.Cookie{Name: "jwt_token",Value: validToken}
     http.SetCookie(w, &cookie)
+	
+	//Add the cookie to the request
+	r.AddCookie(&cookie)
+	
+	//Test that cookie is a valid token
+	_ ,valid := loginh.GetToken(r)
+	if !valid {
+		t.Errorf("loginHandler cookie is not valid")
+	}
 	
 	status, err := h.ServeHTTP(w, r)
 	

--- a/caddy/handler_test.go
+++ b/caddy/handler_test.go
@@ -11,16 +11,16 @@ import (
 	"time"
 )
 
-func Test_ServeHTTP_200(t *testing.T) {	
+func Test_ServeHTTP_200(t *testing.T) {
 	//Set the ServeHTTP *http.Request
 	r, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
 		t.Fatalf("Unable to create request: %v", err)
 	}
-	
+
 	//Set the ServeHTTP http.ResponseWriter
 	w := httptest.NewRecorder()
-	
+
 	//Set the CaddyHandler config
 	configh := login.DefaultConfig()
 	configh.Backends = login.Options{"simple": {"bob": "secret"}}
@@ -28,16 +28,16 @@ func Test_ServeHTTP_200(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected nil error, got: %v", err)
 	}
-	
+
 	//Set the CaddyHandler that will use ServeHTTP
 	h := &CaddyHandler{
-	next: httpserver.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
-		return http.StatusOK, nil // not t.Fatalf, or we will not see what other methods yield
+		next: httpserver.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
+			return http.StatusOK, nil // not t.Fatalf, or we will not see what other methods yield
 		}),
-	config:       login.DefaultConfig(),
-	loginHandler: loginh,
+		config:       login.DefaultConfig(),
+		loginHandler: loginh,
 	}
-	
+
 	//Set user token
 	userInfo := model.UserInfo{Sub: "bob", Expiry: time.Now().Add(time.Second).Unix()}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS512, userInfo)
@@ -45,26 +45,26 @@ func Test_ServeHTTP_200(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected nil error, got: %v", err)
 	}
-	
+
 	//Set cookie for user token on the ServeHTTP http.ResponseWriter
-	cookie := http.Cookie{Name: "jwt_token",Value: validToken, HttpOnly: true}
-    http.SetCookie(w, &cookie)
-	
+	cookie := http.Cookie{Name: "jwt_token", Value: validToken, HttpOnly: true}
+	http.SetCookie(w, &cookie)
+
 	//Add the cookie to the request
 	r.AddCookie(&cookie)
-	
+
 	//Test that cookie is a valid token
-	_ ,valid := loginh.GetToken(r)
+	_, valid := loginh.GetToken(r)
 	if !valid {
 		t.Errorf("loginHandler cookie is not valid")
 	}
-	
+
 	status, err := h.ServeHTTP(w, r)
-	
+
 	if err != nil {
 		t.Errorf("Expected nil error, got: %v", err)
 	}
-	
+
 	if status != 200 {
 		t.Errorf("Expected returned status code to be %d, got %d", 0, status)
 	}
@@ -76,10 +76,10 @@ func Test_ServeHTTP_login(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create request: %v", err)
 	}
-	
+
 	//Set the ServeHTTP http.ResponseWriter
 	w := httptest.NewRecorder()
-	
+
 	//Set the CaddyHandler config
 	configh := login.DefaultConfig()
 	configh.Backends = login.Options{"simple": {"bob": "secret"}}
@@ -87,22 +87,22 @@ func Test_ServeHTTP_login(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected nil error, got: %v", err)
 	}
-	
+
 	//Set the CaddyHandler that will use ServeHTTP
 	h := &CaddyHandler{
-	next: httpserver.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
-		return http.StatusOK, nil // not t.Fatalf, or we will not see what other methods yield
+		next: httpserver.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
+			return http.StatusOK, nil // not t.Fatalf, or we will not see what other methods yield
 		}),
-	config:       login.DefaultConfig(),
-	loginHandler: loginh,
+		config:       login.DefaultConfig(),
+		loginHandler: loginh,
 	}
-	
+
 	status, err := h.ServeHTTP(w, r)
-	
+
 	if err != nil {
 		t.Errorf("Expected nil error, got: %v", err)
 	}
-	
+
 	if status != 0 {
 		t.Errorf("Expected returned status code to be %d, got %d", 0, status)
 	}

--- a/caddy/handler_test.go
+++ b/caddy/handler_test.go
@@ -47,6 +47,7 @@ func Test_ServeHTTP_200(t *testing.T) {
 	}
 	
 	//Set cookie for user token on the ServeHTTP http.ResponseWriter
+	cookie := http.Cookie{Name: "jwt_token",Value: validToken, HttpOnly: true}
     http.SetCookie(w, &cookie)
 	
 	//Add the cookie to the request

--- a/caddy/handler_test.go
+++ b/caddy/handler_test.go
@@ -1,0 +1,47 @@
+package caddy
+
+import (
+	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/tarent/loginsrv/login"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_ServeHTTP_200(t *testing.T) {
+	//Set the ServeHTTP *http.Request
+	r, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("Unable to create request: %v", err)
+	}
+	
+	//Set the ServeHTTP http.ResponseWriter
+	w := httptest.NewRecorder()
+	
+	//Set the CaddyHandler config
+	configh := login.DefaultConfig()
+	configh.Backends = login.Options{"simple": {"bob": "secret"}}
+	loginh, err := login.NewHandler(configh)
+	if err != nil {
+		t.Errorf("Expected nil error, got: %v", err)
+	}
+	
+	//Set the CaddyHandler that will use ServeHTTP
+	h := &CaddyHandler{
+	next: httpserver.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
+		return http.StatusOK, nil // not t.Fatalf, or we will not see what other methods yield
+		}),
+	config:       login.DefaultConfig(),
+	loginHandler: loginh,
+	}
+	
+	status, err := h.ServeHTTP(w, r)
+	
+	if err != nil {
+		t.Errorf("Expected nil error, got: %v", err)
+	}
+	
+	if status != 200 {
+		t.Errorf("Expected returned status code to be %d, got %d", 0, status)
+	}
+}

--- a/caddy/handler_test.go
+++ b/caddy/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+//Tests a page while being logged in as a user (doesn't test that the {user} replacer changes)
 func Test_ServeHTTP_200(t *testing.T) {
 	//Set the ServeHTTP *http.Request
 	r, err := http.NewRequest("GET", "/", nil)
@@ -70,6 +71,7 @@ func Test_ServeHTTP_200(t *testing.T) {
 	}
 }
 
+//Tests the login page without being logged as a user (doesn't test that the {user} replacer stays as-is)
 func Test_ServeHTTP_login(t *testing.T) {
 	//Set the ServeHTTP *http.Request
 	r, err := http.NewRequest("GET", "/login", nil)

--- a/caddy/handler_test.go
+++ b/caddy/handler_test.go
@@ -45,3 +45,41 @@ func Test_ServeHTTP_200(t *testing.T) {
 		t.Errorf("Expected returned status code to be %d, got %d", 0, status)
 	}
 }
+
+func Test_ServeHTTP_login(t *testing.T) {
+	//Set the ServeHTTP *http.Request
+	r, err := http.NewRequest("GET", "/login", nil)
+	if err != nil {
+		t.Fatalf("Unable to create request: %v", err)
+	}
+	
+	//Set the ServeHTTP http.ResponseWriter
+	w := httptest.NewRecorder()
+	
+	//Set the CaddyHandler config
+	configh := login.DefaultConfig()
+	configh.Backends = login.Options{"simple": {"bob": "secret"}}
+	loginh, err := login.NewHandler(configh)
+	if err != nil {
+		t.Errorf("Expected nil error, got: %v", err)
+	}
+	
+	//Set the CaddyHandler that will use ServeHTTP
+	h := &CaddyHandler{
+	next: httpserver.HandlerFunc(func(w http.ResponseWriter, r *http.Request) (int, error) {
+		return http.StatusOK, nil // not t.Fatalf, or we will not see what other methods yield
+		}),
+	config:       login.DefaultConfig(),
+	loginHandler: loginh,
+	}
+	
+	status, err := h.ServeHTTP(w, r)
+	
+	if err != nil {
+		t.Errorf("Expected nil error, got: %v", err)
+	}
+	
+	if status != 0 {
+		t.Errorf("Expected returned status code to be %d, got %d", 0, status)
+	}
+}

--- a/caddy/setup_test.go
+++ b/caddy/setup_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/stretchr/testify/assert"
 	"github.com/tarent/loginsrv/login"
 	"io/ioutil"
+	"path/filepath"
 	"os"
 	"testing"
 	"time"
@@ -176,8 +177,8 @@ func TestSetup(t *testing.T) {
 func TestSetup_RelativeTemplateFile(t *testing.T) {
 	caddyfile := "loginsrv {\n  template myTemplate.tpl\n  simple bob=secret\n}"
 	root, _ := ioutil.TempDir("", "")
-	expectedPath := root + "/myTemplate.tpl"
-
+	expectedPath := filepath.FromSlash(root + "/myTemplate.tpl")
+	
 	c := caddy.NewTestController("http", caddyfile)
 	c.Key = "RelativeTemplateFileTest"
 	config := httpserver.GetConfig(c)

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -244,7 +244,7 @@ func Test_Logger_LifecycleStart(t *testing.T) {
 	a.Equal("b666", data["build_number"])
 }
 
-func Test_Logger_LifecycleStop(t *testing.T) {
+func Test_Logger_LifecycleStop_ByInterrupt(t *testing.T) {
 	a := assert.New(t)
 
 	// given a logger
@@ -264,6 +264,29 @@ func Test_Logger_LifecycleStop(t *testing.T) {
 	a.Equal("lifecycle", data["type"])
 	a.Equal("stop", data["event"])
 	a.Equal("interrupt", data["signal"])
+	a.Equal("b666", data["build_number"])
+}
+
+func Test_Logger_LifecycleStop_ByError(t *testing.T) {
+	a := assert.New(t)
+
+	// given a logger
+	b := bytes.NewBuffer(nil)
+	Logger.Out = b
+
+	// and an Environment Variable with the Build Number is set
+	os.Setenv("BUILD_NUMBER", "b666")
+
+	// when a LifecycleStart is logged
+	LifecycleStop("my-app", nil, errors.New("error"))
+
+	// then: it is logged
+	data := mapFromBuffer(b)
+	a.Equal("error", data["level"])
+	a.Equal("stopping application: my-app (error)", data["message"])
+	a.Equal("lifecycle", data["type"])
+	a.Equal("stop", data["event"])
+	a.Equal(nil, data["signal"])
 	a.Equal("b666", data["build_number"])
 }
 

--- a/logging/logstash_formatter.go
+++ b/logging/logstash_formatter.go
@@ -28,7 +28,7 @@ func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 func (f *LogstashFormatter) FormatWithPrefix(entry *logrus.Entry, prefix string) ([]byte, error) {
 	fields := make(logrus.Fields)
 	for k, v := range entry.Data {
-		//remvove the prefix when sending the fields to logstash
+		//remove the prefix when sending the fields to logstash
 		if prefix != "" && strings.HasPrefix(k, prefix) {
 			k = strings.TrimPrefix(k, prefix)
 		}

--- a/login/handler.go
+++ b/login/handler.go
@@ -246,7 +246,7 @@ func (h *Handler) createToken(userInfo jwt.Claims) (string, error) {
 	return token.SignedString([]byte(h.config.JwtSecret))
 }
 
-func (h *Handler) getToken(r *http.Request) (userInfo model.UserInfo, valid bool) {
+func (h *Handler) GetToken(r *http.Request) (userInfo model.UserInfo, valid bool) {
 	c, err := r.Cookie(h.config.CookieName)
 	if err != nil {
 		return model.UserInfo{}, false

--- a/login/handler.go
+++ b/login/handler.go
@@ -131,7 +131,7 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == "GET" {
-		userInfo, valid := h.getToken(r)
+		userInfo, valid := h.GetToken(r)
 		writeLoginForm(w,
 			loginFormData{
 				Config:        h.config,
@@ -152,7 +152,7 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 			h.handleAuthentication(w, r, username, password)
 			return
 		}
-		userInfo, valid := h.getToken(r)
+		userInfo, valid := h.GetToken(r)
 		if valid {
 			h.handleRefresh(w, r, userInfo)
 			return

--- a/login/handler_test.go
+++ b/login/handler_test.go
@@ -393,7 +393,7 @@ func TestHandler_getToken_Valid(t *testing.T) {
 	r := &http.Request{
 		Header: http.Header{"Cookie": {h.config.CookieName + "=" + token + ";"}},
 	}
-	userInfo, valid := h.getToken(r)
+	userInfo, valid := h.GetToken(r)
 	True(t, valid)
 	Equal(t, input, userInfo)
 }
@@ -410,7 +410,7 @@ func TestHandler_getToken_InvalidSecret(t *testing.T) {
 	// modify secret
 	h.config.JwtSecret = "foobar"
 
-	_, valid := h.getToken(r)
+	_, valid := h.GetToken(r)
 	False(t, valid)
 }
 
@@ -420,13 +420,13 @@ func TestHandler_getToken_InvalidToken(t *testing.T) {
 		Header: http.Header{"Cookie": {h.config.CookieName + "=asdcsadcsadc"}},
 	}
 
-	_, valid := h.getToken(r)
+	_, valid := h.GetToken(r)
 	False(t, valid)
 }
 
 func TestHandler_getToken_InvalidNoToken(t *testing.T) {
 	h := testHandler()
-	_, valid := h.getToken(&http.Request{})
+	_, valid := h.GetToken(&http.Request{})
 	False(t, valid)
 }
 


### PR DESCRIPTION
I tested it on Windows 7 x64 and it works.

I've not added tests yet.

@smancke please review it. I'm unsure if it is the best way to add this feature.