### PR TITLE
login-picture auto width

### DIFF
--- a/login/login_form.go
+++ b/login/login_form.go
@@ -44,7 +44,6 @@ const partials = `
        background-color: #FFF;
      }
      .login-picture {
-       width: 120px;
        height: 120px;
        border-radius: 3px;
        margin-bottom: 10px;


### PR DESCRIPTION
Avoids badly proportioned non-square profile pictures. We could explicitly declare `width: auto;` as well?