### PR TITLE
Adjust behavior on empty username and token refresh

### DIFF
--- a/login/handler.go
+++ b/login/handler.go
@@ -172,6 +172,11 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 			h.handleRefresh(w, r, userInfo)
 			return
 		}
+		if username == "" {
+			h.respondAuthFailure(w, r)
+			return
+		}
+		
 		h.respondBadRequest(w, r)
 		return
 	}

--- a/login/handler_test.go
+++ b/login/handler_test.go
@@ -281,7 +281,7 @@ func TestHandler_Refresh_Expired(t *testing.T) {
 
 	// refreshSuccess
 	recorder := call(req("POST", "/context/login", "", AcceptHTML, cookieStr))
-	Equal(t, 400, recorder.Code)
+	Equal(t, 403, recorder.Code)
 
 	// verify the token from the cookie
 	setCookieList := readSetCookies(recorder.Header())
@@ -295,7 +295,7 @@ func TestHandler_Refresh_Invalid_Token(t *testing.T) {
 
 	// refreshSuccess
 	recorder := call(req("POST", "/context/login", "", AcceptHTML, cookieStr))
-	Equal(t, 400, recorder.Code)
+	Equal(t, 403, recorder.Code)
 
 	// verify the token from the cookie
 	setCookieList := readSetCookies(recorder.Header())

--- a/login/handler_test.go
+++ b/login/handler_test.go
@@ -388,6 +388,19 @@ func TestHandler_LoginError(t *testing.T) {
 	Contains(t, recorder.Body.String(), "Internal Error")
 }
 
+func TestHandler_LoginWithEmptyUsername(t *testing.T) {
+	h := testHandler()
+
+	// backend returning an error with result type == jwt
+	request := req("POST", "/context/login", `{"username": "", "password": ""}`, TypeJSON, AcceptJwt)
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, request)
+
+	Equal(t, 403, recorder.Code)
+	Equal(t, recorder.Header().Get("Content-Type"), "text/plain")
+	Equal(t, recorder.Body.String(), "Wrong credentials")
+}
+
 func TestHandler_getToken_Valid(t *testing.T) {
 	h := testHandler()
 	input := model.UserInfo{Sub: "marvin", Expiry: time.Now().Add(time.Second).Unix()}


### PR DESCRIPTION
This PR is a try to adjust behavior to resolve #71.

It changes behavior in 3 cases:
1) empty username now returns a 403 instead of a page with `Bad Request: Method or content-type not supported`
2) Refreshing an expired token returns a 403 instead of a 400
3) Refreshing an invalid token returns a 403 instead of a 400

@smancke please review it and confirm if these behavior are acceptable in these cases.