### PR TITLE
Remove undocumented "files" parameter for htpasswd and enhance doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Parameters for the provider:
 
 | Parameter-Name    | Description                |
 | ------------------|----------------------------|
-| file              | Path to the password file  |
+| file              | Path to the password file (multiple files can be used by separating them with ';')  |
 
 Example:
 ```

--- a/htpasswd/backend.go
+++ b/htpasswd/backend.go
@@ -23,12 +23,6 @@ func init() {
 func BackendFactory(config map[string]string) (login.Backend, error) {
 	var files []string
 
-	if f, exist := config["files"]; exist {
-		for _, file := range strings.Split(f, ";") {
-			files = append(files, file)
-		}
-	}
-
 	if f, exist := config["file"]; exist {
 		for _, file := range strings.Split(f, ";") {
 			files = append(files, file)

--- a/htpasswd/backend_test.go
+++ b/htpasswd/backend_test.go
@@ -44,29 +44,6 @@ func TestSetupTwoFiles(t *testing.T) {
 		backend.(*Backend).auth.filenames)
 }
 
-func TestSetupTwoConfigs(t *testing.T) {
-	p, exist := login.GetProvider(ProviderName)
-	True(t, exist)
-	NotNil(t, p)
-
-	configFiles := writeTmpfile(testfile, testfile)
-	configFile := writeTmpfile(testfile, testfile)
-
-	var morphed []File
-	for _, curFile := range append(configFiles, configFile...) {
-		morphed = append(morphed, File{name: curFile})
-	}
-
-	backend, err := p(map[string]string{
-		"file":  strings.Join(configFile, ";"),
-	})
-
-	NoError(t, err)
-	Equal(t,
-		morphed,
-		backend.(*Backend).auth.filenames)
-}
-
 func TestSetup_Error(t *testing.T) {
 	p, exist := login.GetProvider(ProviderName)
 	True(t, exist)

--- a/htpasswd/backend_test.go
+++ b/htpasswd/backend_test.go
@@ -58,7 +58,6 @@ func TestSetupTwoConfigs(t *testing.T) {
 	}
 
 	backend, err := p(map[string]string{
-		"files": strings.Join(configFiles, ";"),
 		"file":  strings.Join(configFile, ";"),
 	})
 


### PR DESCRIPTION
This is a fix for #39.

It removes an undocumented parameter and enhances the doc in the main page on a related feature.