### PR TITLE
Minor correction for cross-platform filepath

### DIFF
--- a/caddy/setup_test.go
+++ b/caddy/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -221,6 +222,6 @@ func TestSetup_RelativeFiles(t *testing.T) {
 	}
 	middleware := mids[len(mids)-1](nil).(*CaddyHandler)
 
-	Equal(t, root+"/myTemplate.tpl", middleware.config.Template)
+	Equal(t, filepath.FromSlash(root + "/myTemplate.tpl"), middleware.config.Template)
 	Equal(t, "redirectDomains.txt", middleware.config.RedirectHostFile)
 }


### PR DESCRIPTION
This test fails on Windows 7 x64 without this small adjustment.

This commit is similar to https://github.com/tarent/loginsrv/commit/8c99657f77f73d2d5b784e673eb4cd6694e3664f.