### PR TITLE
Allow Bcrypt $2a$ prefix

### DIFF
--- a/htpasswd/auth.go
+++ b/htpasswd/auth.go
@@ -97,7 +97,7 @@ func (a *Auth) Authenticate(username, password string) (bool, error) {
 	if hash, exist := a.userHash[username]; exist {
 		h := []byte(hash)
 		p := []byte(password)
-		if strings.HasPrefix(hash, "$2y$") || strings.HasPrefix(hash, "$2b$") {
+		if strings.HasPrefix(hash, "$2y$") || strings.HasPrefix(hash, "$2b$") || strings.HasPrefix(hash, "$2a$") {
 			matchErr := bcrypt.CompareHashAndPassword(h, p)
 			return (matchErr == nil), nil
 		}


### PR DESCRIPTION
As asked for with the comment on the issue I posted.
golang.org/x/crypto/bcrypt, generate $2a$ bcrypt prefix, so it would be logical to authenticate against this prefix as well...