### PR TITLE
Add viewport meta tag to get proper scaling on mobile

### DIFF
--- a/login/login_form.go
+++ b/login/login_form.go
@@ -104,6 +104,7 @@ const partials = `
 var layout = `<!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ template "styles" . }}
   </head>
   <body>


### PR DESCRIPTION
Add the viewport meta tag given in the Bootstrap documentation: https://getbootstrap.com/docs/3.3/getting-started/#template
Without it, the interface looks tiny on mobile:
![a87146e9-e2ce-44d8-b13a-1be4a8e5d20b](https://user-images.githubusercontent.com/1939395/46348526-8e7be380-c64f-11e8-8523-9b118b1fdeb8.jpeg)
