### PR TITLE
Added flag to allow redirect between subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ _Note for Caddy users_: Not all parameters are available in Caddy. See the table
 | -osiam                      | value       |              | X     | OSIAM login backend opts: endpoint=..,client_id=..,client_secret=..                                   |
 | -port                       | string      | "6789"       | -     | Port to listen on                                                                                     |
 | -redirect                   | boolean     | true         | X     | Allow dynamic overwriting of the the success by query parameter                                       |
+| -redirect-allow-subdomain   | bool        | false        | X     | If true redirect is allowed when the target is on a different subdomain                               |
 | -redirect-query-parameter   | string      | "backTo"     | X     | URL parameter for the redirect target                                                                 |
 | -redirect-check-referer     | boolean     | true         | X     | Check the referer header to ensure it matches the host header on dynamic redirects                    |
 | -redirect-host-file         | string      | ""           | X     | A file containing a list of domains that redirects are allowed to, one domain per line                |

--- a/caddy/setup_test.go
+++ b/caddy/setup_test.go
@@ -43,6 +43,7 @@ func TestSetup(t *testing.T) {
                                         redirect_query_parameter comingFrom
                                         redirect_check_referer true
                                         redirect_host_file domainWhitelist.txt
+                                        redirect_allow_subdomain true
                                         cookie_name cookiename
                                         cookie_http_only false
                                         cookie_domain example.com
@@ -60,6 +61,7 @@ func TestSetup(t *testing.T) {
 				Equal(t, cfg.RedirectQueryParameter, "comingFrom")
 				Equal(t, cfg.RedirectCheckReferer, true)
 				Equal(t, cfg.RedirectHostFile, "domainWhitelist.txt")
+				Equal(t, cfg.RedirectAllowSubdomain, true)
 				Equal(t, cfg.CookieName, "cookiename")
 				Equal(t, cfg.CookieHTTPOnly, false)
 				Equal(t, cfg.CookieDomain, "example.com")

--- a/login/config.go
+++ b/login/config.go
@@ -40,6 +40,7 @@ func DefaultConfig() *Config {
 		RedirectQueryParameter: "backTo",
 		RedirectCheckReferer:   true,
 		RedirectHostFile:       "",
+		RedirectAllowSubdomain: false,
 		LogoutURL:              "",
 		LoginPath:              "/login",
 		CookieName:             "jwt_token",
@@ -73,6 +74,7 @@ type Config struct {
 	RedirectQueryParameter string
 	RedirectCheckReferer   bool
 	RedirectHostFile       string
+	RedirectAllowSubdomain bool
 	LogoutURL              string
 	Template               string
 	LoginPath              string
@@ -152,6 +154,7 @@ func (c *Config) ConfigureFlagSet(f *flag.FlagSet) {
 	f.StringVar(&c.RedirectQueryParameter, "redirect-query-parameter", c.RedirectQueryParameter, "URL parameter for the redirect target")
 	f.BoolVar(&c.RedirectCheckReferer, "redirect-check-referer", c.RedirectCheckReferer, "When redirecting check that the referer is the same domain")
 	f.StringVar(&c.RedirectHostFile, "redirect-host-file", c.RedirectHostFile, "A file containing a list of domains that redirects are allowed to, one domain per line")
+	f.BoolVar(&c.RedirectAllowSubdomain, "redirect-allow-subdomain", c.RedirectAllowSubdomain, "If true a redirect is allowed if the target is a different subdomain than loginsrv")
 
 	f.StringVar(&c.LogoutURL, "logout-url", c.LogoutURL, "The url or path to redirect after logout")
 	f.StringVar(&c.Template, "template", c.Template, "An alternative template for the login form")

--- a/login/redirect.go
+++ b/login/redirect.go
@@ -49,11 +49,40 @@ func (h *Handler) allowRedirect(r *http.Request) bool {
 		logging.Application(r.Header).Warnf("couldn't parse redirect url %s", err)
 		return false
 	}
+
 	if referer.Host != r.Host {
 		logging.Application(r.Header).Warnf("redirect from referer domain: '%s', not matching current domain '%s'", referer.Host, r.Host)
 		return false
 	}
 	return true
+}
+
+func removeSubdomain(host string) string {
+	parts := strings.Split(host, ".")
+	if len(parts) == 1 {
+		return host
+	}
+	return strings.Join(parts[1:], ".")
+}
+
+// haveSubdomain checks that there's at least one subdomain
+func haveSubdomain(host string) bool {
+	trimmed := strings.Trim(host, ".")
+	parts := strings.Split(trimmed, ".")
+	return len(parts) > 2
+}
+
+func (h *Handler) isSubdomainAllowed(target string, host string) bool {
+	if !h.config.RedirectAllowSubdomain {
+		return false
+	}
+	if target == "" || host == "" {
+		return false
+	}
+	if !haveSubdomain(target) || !haveSubdomain(host) {
+		return false
+	}
+	return removeSubdomain(target) == removeSubdomain(host)
 }
 
 func (h *Handler) redirectURL(r *http.Request, w http.ResponseWriter) string {
@@ -62,6 +91,9 @@ func (h *Handler) redirectURL(r *http.Request, w http.ResponseWriter) string {
 		sameHost := targetURL.Host == "" || r.Host == targetURL.Host
 		if sameHost && targetURL.Path != "" {
 			return targetURL.Path
+		}
+		if h.isSubdomainAllowed(targetURL.Host, r.Host) {
+			return targetURL.String()
 		}
 		if !sameHost && h.isRedirectDomainWhitelisted(r, targetURL.Host) {
 			return targetURL.String()


### PR DESCRIPTION
This allows loginsrv to be hosted at `login.home.com` and redirect to any other subdomain under `home.com`