### PR TITLE
fix login failure when JSON content type includes charset

### DIFF
--- a/login/handler.go
+++ b/login/handler.go
@@ -408,7 +408,7 @@ func wantJSON(r *http.Request) bool {
 }
 
 func getCredentials(r *http.Request) (string, string, error) {
-	if r.Header.Get("Content-Type") == contentTypeJSON {
+	if strings.HasPrefix(r.Header.Get("Content-Type"), contentTypeJSON) {
 		m := map[string]string{}
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {


### PR DESCRIPTION
Hello, the requests are failing when their `Content-Type`  header includes their charset. This is because the validation of credentials required a literal equality for the content type. I just did correct the check.

Thank you for the package.