### PR TITLE
Add Discord OAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following providers (login backends) are supported.
   * Bitbucket login
   * Facebook login
   * Gitlab login
+  * Discord login
 
 ## Questions
 
@@ -68,6 +69,7 @@ _Note for Caddy users_: Not all parameters are available in Caddy. See the table
 | -bitbucket                  | value       |              | X     | OAuth config in the form: client_id=..,client_secret=..[,scope=..][,redirect_uri=..]       |
 | -facebook                   | value       |              | X     | OAuth config in the form: client_id=..,client_secret=..[,scope=..][,redirect_uri=..]       |
 | -gitlab                     | value       |              | X     | OAuth config in the form: client_id=..,client_secret=..[,scope=..,][redirect_uri=..]       |
+| -discord                    | value       |              | X     | OAuth config in the form: client_id=..,client_secret=..[,scope=..,][redirect_uri=..]       |
 | -host                       | string      | "localhost"  | -     | Host to listen on                                                                          |
 | -htpasswd                   | value       |              | X     | Htpasswd login backend opts: file=/path/to/pwdfile                                         |
 | -jwt-expiry                 | go duration | 24h          | X     | Expiry duration for the JWT token, e.g. 2h or 3h30m                                        |
@@ -314,6 +316,7 @@ Currently the following OAuth provider is supported:
 * Bitbucket
 * Facebook
 * Gitlab
+* Discord
 
 An OAuth provider supports the following parameters:
 
@@ -392,7 +395,7 @@ below the claim attribute are written into the token. The following attributes c
 * `origin` - the provider or backend name (all backends)
 * `email` - the mail address (the OAuth provider)
 * `domain` - the domain (Google only)
-* `groups` - the full path string of user groups enclosed in an array (Gitlab only)
+* `groups` - the full path string of user groups enclosed in an array (Gitlab/Discord only)
 
 Example:
 * The user bob will become the `"role": "superAdmin"`, when authenticating with htpasswd file

--- a/htpasswd/auth.go
+++ b/htpasswd/auth.go
@@ -7,14 +7,15 @@ import (
 	"encoding/base64"
 	"encoding/csv"
 	"fmt"
-	"github.com/abbot/go-http-auth"
-	"github.com/tarent/loginsrv/logging"
-	"golang.org/x/crypto/bcrypt"
 	"io"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	auth "github.com/abbot/go-http-auth"
+	"github.com/tarent/loginsrv/logging"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // File is a struct to serve an individual modTime

--- a/htpasswd/auth_test.go
+++ b/htpasswd/auth_test.go
@@ -1,11 +1,12 @@
 package htpasswd
 
 import (
-	. "github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
+
+	. "github.com/stretchr/testify/assert"
 )
 
 // password for all of them is 'secret'

--- a/htpasswd/backend.go
+++ b/htpasswd/backend.go
@@ -2,9 +2,10 @@ package htpasswd
 
 import (
 	"errors"
+	"strings"
+
 	"github.com/tarent/loginsrv/login"
 	"github.com/tarent/loginsrv/model"
-	"strings"
 )
 
 // ProviderName const

--- a/htpasswd/backend_test.go
+++ b/htpasswd/backend_test.go
@@ -1,12 +1,13 @@
 package htpasswd
 
 import (
-	. "github.com/stretchr/testify/assert"
-	"github.com/tarent/loginsrv/login"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	. "github.com/stretchr/testify/assert"
+	"github.com/tarent/loginsrv/login"
 )
 
 func TestSetupOneFile(t *testing.T) {

--- a/httpupstream/auth_test.go
+++ b/httpupstream/auth_test.go
@@ -47,10 +47,10 @@ func TestAuth_ValidCredentials(t *testing.T) {
 	True(t, authenticated)
 }
 
-func TestAuth_InvalidUrl(t *testing.T) {
-	invalidUrl := &url.URL{Scheme: "\\\\"}
+func TestAuth_InvalidURL(t *testing.T) {
+	invalidURL := &url.URL{Scheme: "\\\\"}
 
-	auth, err := NewAuth(invalidUrl, time.Second, false)
+	auth, err := NewAuth(invalidURL, time.Second, false)
 	NoError(t, err)
 
 	_, err = auth.Authenticate("foo", "bar")

--- a/login/login_form_test.go
+++ b/login/login_form_test.go
@@ -1,12 +1,13 @@
 package login
 
 import (
-	. "github.com/stretchr/testify/assert"
-	"github.com/tarent/loginsrv/model"
 	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	. "github.com/stretchr/testify/assert"
+	"github.com/tarent/loginsrv/model"
 )
 
 func Test_form(t *testing.T) {

--- a/login/simple_backend.go
+++ b/login/simple_backend.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"errors"
+
 	"github.com/tarent/loginsrv/model"
 )
 

--- a/login/simple_backend_test.go
+++ b/login/simple_backend_test.go
@@ -1,8 +1,9 @@
 package login
 
 import (
-	. "github.com/stretchr/testify/assert"
 	"testing"
+
+	. "github.com/stretchr/testify/assert"
 )
 
 func TestSetup(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"github.com/dgrijalva/jwt-go"
-	. "github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	. "github.com/stretchr/testify/assert"
 )
 
 func Test_BasicEndToEnd(t *testing.T) {

--- a/oauth2/bitbucket.go
+++ b/oauth2/bitbucket.go
@@ -59,9 +59,9 @@ func (e *emails) getPrimaryEmailAddress() string {
 
 // getBitbucketEmails Retrieves bitbucket user emails from the Bitbucket API emails service
 func getBitbucketEmails(token TokenInfo) (emails, error) {
-	emailUrl := fmt.Sprintf("%v/user/emails?access_token=%v", bitbucketAPI, token.AccessToken)
+	emailURL := fmt.Sprintf("%v/user/emails?access_token=%v", bitbucketAPI, token.AccessToken)
 	userEmails := emails{}
-	resp, err := http.Get(emailUrl)
+	resp, err := http.Get(emailURL)
 
 	if err != nil {
 		return emails{}, err

--- a/oauth2/bitbucket_test.go
+++ b/oauth2/bitbucket_test.go
@@ -1,12 +1,13 @@
 package oauth2
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/suite"
-	"encoding/json"
 )
 
 var bitbucketTestUserResponse = `{
@@ -118,7 +119,7 @@ func (suite *BitbucketTestSuite) Test_Bitbucket_getUserInfo() {
 }
 
 // Test_Bitbucket_getPrimaryEmailAddress Tests the returned primary email is the expected email
-func (suite *BitbucketTestSuite) Test_Bitbucket_getPrimaryEmailAddress()  {
+func (suite *BitbucketTestSuite) Test_Bitbucket_getPrimaryEmailAddress() {
 	userEmails := emails{}
 	err := json.Unmarshal([]byte(bitbucketTestUserEmailResponse), &userEmails)
 	suite.NoError(err)

--- a/oauth2/discord.go
+++ b/oauth2/discord.go
@@ -1,0 +1,114 @@
+package oauth2
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/tarent/loginsrv/model"
+)
+
+var discordAPI = "https://discordapp.com/api"
+var discordCDN = "https://cdn.discordapp.com"
+
+func init() {
+	RegisterProvider(providerDiscord)
+}
+
+// DiscordUser is used for parsing the github response
+type DiscordUser struct {
+	ID            string `json:"id,omitempty"`
+	Username      string `json:"username,omitempty"`
+	Discriminator string `json:"discriminator,omitempty"`
+	AvatarHash    string `json:"avatar,omitempty"`
+	MFAEnabled    bool   `json:"mfa_enabled,omitempty"`
+	Locale        string `json:"locale,omitempty"`
+	Verified      bool   `json:"verified,omitempty"`
+	Email         string `json:"email,omitempty"`
+	Flags         int    `json:"flags,omitempty"`
+	PremiumType   int    `json:"premium_type,omitempty"`
+}
+
+// DiscordGuild is a partial guild object returned by the /user/guilds endpoint
+type DiscordGuild struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	IconHash    string `json:"icon,omitempty"`
+	Owner       bool   `json:"owner,omitempty"`
+	Permissions int    `json:"permissions,omitempty"`
+}
+
+func discordAPIRequest(endpoint, token string) ([]byte, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%v/%v", discordAPI, endpoint), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %v", err)
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if !strings.Contains(resp.Header.Get("Content-Type"), "application/json") {
+		return nil, fmt.Errorf("wrong content-type: %v", resp.Header.Get("Content-Type"))
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("got http status %v", resp.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading body: %v", err)
+	}
+
+	return b, nil
+}
+
+var providerDiscord = Provider{
+	Name:          "discord",
+	AuthURL:       "https://discordapp.com/api/oauth2/authorize?prompt=none",
+	TokenURL:      "https://discordapp.com/api/oauth2/token",
+	DefaultScopes: "identify email guilds",
+	GetUserInfo: func(token TokenInfo) (model.UserInfo, string, error) {
+		du := DiscordUser{}
+		dg := []DiscordGuild{}
+		// Get user info
+		raw, err := discordAPIRequest("/users/@me", token.AccessToken)
+		if err != nil {
+			return model.UserInfo{}, "", fmt.Errorf("error getting discord user info: %v", err)
+		}
+		err = json.Unmarshal(raw, &du)
+		if err != nil {
+			return model.UserInfo{}, "", fmt.Errorf("error parsing discord get user info: %v", err)
+		}
+
+		// Get user's guilds (servers)
+		raw, err = discordAPIRequest("/users/@me/guilds", token.AccessToken)
+		if err != nil {
+			return model.UserInfo{}, "", fmt.Errorf("error getting discord user guilds: %v", err)
+		}
+		err = json.Unmarshal(raw, &dg)
+		if err != nil {
+			return model.UserInfo{}, "", fmt.Errorf("error parsing discord guilds: %v", err)
+		}
+
+		var guilds []string
+		for _, g := range dg {
+			guilds = append(guilds, g.ID)
+		}
+
+		return model.UserInfo{
+			Sub:     fmt.Sprintf("%v#%v", du.Username, du.Discriminator),
+			Picture: fmt.Sprintf("%v/avatars/%v/%v.png", discordCDN, du.ID, du.AvatarHash),
+			Name:    du.Username,
+			Email:   du.Email,
+			Origin:  "discord",
+			Groups:  guilds,
+		}, string(raw), nil
+	},
+}

--- a/oauth2/discord_test.go
+++ b/oauth2/discord_test.go
@@ -1,0 +1,67 @@
+package oauth2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	. "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+var discordTestUserResponse = `{
+	"id": "80351110224678912",
+	"username": "Nelly",
+	"discriminator": "1337",
+	"avatar": "8342729096ea3675442027381ff50dfe",
+	"verified": true,
+	"email": "nelly@discordapp.com",
+	"flags": 64,
+	"premium_type": 1
+  }`
+
+var discordTestUserGuildsResponse = `[
+	{
+		"id": "80351110224678912",
+		"name": "1337 Krew",
+		"icon": "8342729096ea3675442027381ff50dfe",
+		"owner": true,
+		"permissions": 36953089
+	}
+]`
+
+type DiscordTestSuite struct {
+	suite.Suite
+	Server *httptest.Server
+}
+
+func (suite *DiscordTestSuite) SetupTest() {
+	r := mux.NewRouter()
+
+	r.HandleFunc("/users/@me", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(r.Header.Get("Authentication"), "Bearer secret")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Write([]byte(discordTestUserResponse))
+	})
+
+	r.HandleFunc("/users/@me/guilds", func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal(r.Header.Get("Authentication"), "Bearer secret")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Write([]byte(discordTestUserGuildsResponse))
+	})
+
+	suite.Server = httptest.NewServer(r)
+}
+
+func (suite *DiscordTestSuite) Test_Discord_getUserInfo(t *testing.T) {
+	discordAPI = suite.Server.URL
+
+	u, rawJSON, err := providerDiscord.GetUserInfo(TokenInfo{AccessToken: "secret"})
+	NoError(t, err)
+	Equal(t, "Nelly#1337", u.Sub)
+	Equal(t, "nelly@discordapp.com", u.Email)
+	Equal(t, "Nelly", u.Name)
+	Equal(t, []string{"80351110224678912"}, u.Groups)
+	Equal(t, discordTestUserResponse, rawJSON)
+}

--- a/oauth2/facebook_test.go
+++ b/oauth2/facebook_test.go
@@ -1,10 +1,11 @@
 package oauth2
 
 import (
-	. "github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	. "github.com/stretchr/testify/assert"
 )
 
 var facebookTestUserResponse = `{

--- a/oauth2/github_test.go
+++ b/oauth2/github_test.go
@@ -1,10 +1,11 @@
 package oauth2
 
 import (
-	. "github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	. "github.com/stretchr/testify/assert"
 )
 
 var githubTestUserResponse = `{

--- a/oauth2/google.go
+++ b/oauth2/google.go
@@ -10,7 +10,6 @@ import (
 	"github.com/tarent/loginsrv/model"
 )
 
-
 var googleUserinfoEndpoint = "https://www.googleapis.com/oauth2/v3/userinfo"
 
 func init() {

--- a/oauth2/manager.go
+++ b/oauth2/manager.go
@@ -2,10 +2,11 @@ package oauth2
 
 import (
 	"fmt"
-	"github.com/tarent/loginsrv/model"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/tarent/loginsrv/model"
 )
 
 // Manager has the responsibility to handle the user user requests in an oauth flow.

--- a/oauth2/manager.go
+++ b/oauth2/manager.go
@@ -95,10 +95,20 @@ func (manager *Manager) AddConfig(providerName string, opts map[string]string) e
 		return fmt.Errorf("no provider for name %v", providerName)
 	}
 
+	authURL, err := url.Parse(p.AuthURL)
+	if err != nil {
+		return fmt.Errorf("parse auth URL: %s", err)
+	}
+
+	tokenURL, err := url.Parse(p.TokenURL)
+	if err != nil {
+		return fmt.Errorf("parse token URL: %s", err)
+	}
+
 	cfg := Config{
 		Provider: p,
-		AuthURL:  p.AuthURL,
-		TokenURL: p.TokenURL,
+		AuthURL:  authURL,
+		TokenURL: tokenURL,
 	}
 
 	clientID, exist := opts["client_id"]

--- a/oauth2/manager_test.go
+++ b/oauth2/manager_test.go
@@ -34,8 +34,8 @@ func Test_Manager_Positive_Flow(t *testing.T) {
 	expectedConfig := Config{
 		ClientID:     "client42",
 		ClientSecret: "secret",
-		AuthURL:      exampleProvider.AuthURL,
-		TokenURL:     exampleProvider.TokenURL,
+		AuthURL:      mustParseURL(exampleProvider.AuthURL),
+		TokenURL:     mustParseURL(exampleProvider.TokenURL),
 		RedirectURI:  "http://localhost",
 		Scope:        "email other",
 		Provider:     exampleProvider,

--- a/oauth2/manager_test.go
+++ b/oauth2/manager_test.go
@@ -3,11 +3,12 @@ package oauth2
 import (
 	"crypto/tls"
 	"errors"
-	. "github.com/stretchr/testify/assert"
-	"github.com/tarent/loginsrv/model"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	. "github.com/stretchr/testify/assert"
+	"github.com/tarent/loginsrv/model"
 )
 
 func Test_Manager_Positive_Flow(t *testing.T) {

--- a/oauth2/oauth_test.go
+++ b/oauth2/oauth_test.go
@@ -2,13 +2,14 @@ package oauth2
 
 import (
 	"fmt"
-	. "github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	. "github.com/stretchr/testify/assert"
 )
 
 var testConfig = Config{

--- a/oauth2/provider.go
+++ b/oauth2/provider.go
@@ -21,8 +21,6 @@ type Provider struct {
 
 	// GetUserInfo is a provider specific Implementation
 	// for fetching the user information.
-	// Possible keys in the returned map are:
-	// username, email, name
 	GetUserInfo func(token TokenInfo) (u model.UserInfo, rawUserJson string, err error)
 }
 

--- a/oauth2/provider_test.go
+++ b/oauth2/provider_test.go
@@ -27,11 +27,16 @@ func Test_ProviderRegistration(t *testing.T) {
 	NotNil(t, gitlab)
 	True(t, exist)
 
+	discord, exist := GetProvider("discord")
+	NotNil(t, discord)
+	True(t, exist)
+
 	list := ProviderList()
-	Equal(t, 5, len(list))
+	Equal(t, 6, len(list))
 	Contains(t, list, "github")
 	Contains(t, list, "google")
 	Contains(t, list, "bitbucket")
 	Contains(t, list, "facebook")
 	Contains(t, list, "gitlab")
+	Contains(t, list, "discord")
 }

--- a/osiam/backend_test.go
+++ b/osiam/backend_test.go
@@ -1,11 +1,12 @@
 package osiam
 
 import (
-	. "github.com/stretchr/testify/assert"
-	"github.com/tarent/loginsrv/model"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	. "github.com/stretchr/testify/assert"
+	"github.com/tarent/loginsrv/model"
 )
 
 func TestBackend_Authenticate(t *testing.T) {

--- a/osiam/client_test.go
+++ b/osiam/client_test.go
@@ -2,12 +2,13 @@ package osiam
 
 import (
 	"fmt"
-	. "github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	. "github.com/stretchr/testify/assert"
 )
 
 func TestClient_GetTokenByPassword(t *testing.T) {

--- a/osiam/error_test.go
+++ b/osiam/error_test.go
@@ -1,8 +1,9 @@
 package osiam
 
 import (
-	. "github.com/stretchr/testify/assert"
 	"testing"
+
+	. "github.com/stretchr/testify/assert"
 )
 
 func TestError_ParseOsiamError_CornerCases(t *testing.T) {

--- a/osiam/token_test.go
+++ b/osiam/token_test.go
@@ -2,9 +2,10 @@ package osiam
 
 import (
 	"encoding/json"
-	. "github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	. "github.com/stretchr/testify/assert"
 )
 
 var testToken = &Token{


### PR DESCRIPTION
- Adds support for Discord OAuth. User Name (discord username), Email, Sub (discord username plus "discriminant", which uniquely identifies a discord user), and picture are populated.
- In addition, a User's guilds (discord servers) are fetched and populate the Groups field. This allows ( along with userlist.yaml) authorizing users based on their membership of discord servers.
- Minor linting
- Parse a provider's OAuth URLs when generating a config, allowing them to contain extra parameters. This was needed to support discord's prompt parameter[1]

closes: #119

[1]: https://discordapp.com/developers/docs/topics/oauth2#authorization-code-grant