### PR TITLE
Fix up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: go
 
 go:
+  - "1.12"
+  - "1.13"
   - tip
+
+# Allow builds from tip to fail - they might be in an unstable state
+jobs:
+  allow_failures:
+    - go: tip
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
Don't only build against tip, but also 1.12 and 1.13. tip builds are considered failable, as tip might be in an unstable state.