### PR TITLE
Fix up broken tip build

### DIFF
--- a/logging/logstash_formatter_test.go
+++ b/logging/logstash_formatter_test.go
@@ -17,6 +17,8 @@ import (
 func TestLogstashFormatter(t *testing.T) {
 	lf := LogstashFormatter{Type: "abc"}
 
+	someErr := &url.Error{Op: "Get", URL: "http://example.com", Err: fmt.Errorf("The error")}
+
 	fields := logrus.Fields{
 		"message": "def",
 		"level":   "ijk",
@@ -24,7 +26,7 @@ func TestLogstashFormatter(t *testing.T) {
 		"one":     1,
 		"pi":      3.14,
 		"bool":    true,
-		"error":   &url.Error{Op: "Get", URL: "http://example.com", Err: fmt.Errorf("The error")},
+		"error":   someErr,
 	}
 
 	entry := logrus.WithFields(fields)
@@ -51,7 +53,7 @@ func TestLogstashFormatter(t *testing.T) {
 		{"abc", "type"},
 		{"msg", "message"},
 		{"info", "level"},
-		{"Get http://example.com: The error", "error"},
+		{someErr.Error(), "error"},
 		// substituted fields
 		{"def", "fields.message"},
 		{"ijk", "fields.level"},


### PR DESCRIPTION
go 1.14 will quote the url in a url.Error. Thus, the check in the logstash formatter test should be a bit more lenient.

Also see:
https://github.com/golang/go/commit/64cfe9fe22113cd6bc05a2c5d0cbe872b1b57860