### PR TITLE
WIP: Build on arm64 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ jobs:
   allow_failures:
     - go: tip
 
+arch:
+  - amd64
+  - arm64
+
 env:
   - GO111MODULE=on
 
@@ -31,6 +35,7 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
+    condition: $ARCH = amd64
 
 after_success:
   - ./.generate_coverage.sh


### PR DESCRIPTION
Well, it would be cool to have an arm64 docker image. That could e.g. allow loginsrv to run on an raspberry pi.

This is an WIP PR to get the travis build running.