### PR TITLE
Use crypto/rand

### DIFF
--- a/login/config.go
+++ b/login/config.go
@@ -1,11 +1,12 @@
 package login
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -17,8 +18,11 @@ import (
 var jwtDefaultSecret string
 
 func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
-	jwtDefaultSecret = randStringBytes(32)
+	var err error
+	jwtDefaultSecret, err = randStringBytes(32)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // DefaultConfig for the loginsrv handler
@@ -231,14 +235,13 @@ func readConfig(f *flag.FlagSet, args []string) (*Config, error) {
 	return config, err
 }
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-func randStringBytes(n int) string {
+func randStringBytes(n int) (string, error) {
 	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
 	}
-	return string(b)
+	return hex.EncodeToString(b), nil
 }
 
 func envName(flagName string) string {

--- a/login/config.go
+++ b/login/config.go
@@ -19,7 +19,7 @@ var jwtDefaultSecret string
 
 func init() {
 	var err error
-	jwtDefaultSecret, err = randStringBytes(32)
+	jwtDefaultSecret, err = randStringBytes(64)
 	if err != nil {
 		panic(err)
 	}

--- a/oauth2/manager.go
+++ b/oauth2/manager.go
@@ -2,17 +2,18 @@ package oauth2
 
 import (
 	"fmt"
-	"github.com/tarent/loginsrv/model"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/tarent/loginsrv/model"
 )
 
 // Manager has the responsibility to handle the user user requests in an oauth flow.
 // It has to pick the right configuration and start the oauth redirecting.
 type Manager struct {
 	configs      map[string]Config
-	startFlow    func(cfg Config, w http.ResponseWriter)
+	startFlow    func(cfg Config, w http.ResponseWriter) error
 	authenticate func(cfg Config, r *http.Request) (TokenInfo, error)
 }
 

--- a/oauth2/manager_test.go
+++ b/oauth2/manager_test.go
@@ -3,11 +3,12 @@ package oauth2
 import (
 	"crypto/tls"
 	"errors"
-	. "github.com/stretchr/testify/assert"
-	"github.com/tarent/loginsrv/model"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	. "github.com/stretchr/testify/assert"
+	"github.com/tarent/loginsrv/model"
 )
 
 func Test_Manager_Positive_Flow(t *testing.T) {
@@ -48,9 +49,10 @@ func Test_Manager_Positive_Flow(t *testing.T) {
 		"redirect_uri":  expectedConfig.RedirectURI,
 	})
 
-	m.startFlow = func(cfg Config, w http.ResponseWriter) {
+	m.startFlow = func(cfg Config, w http.ResponseWriter) error {
 		startFlowCalled = true
 		startFlowReceivedConfig = cfg
+		return nil
 	}
 
 	m.authenticate = func(cfg Config, r *http.Request) (TokenInfo, error) {
@@ -233,8 +235,9 @@ func Test_Manager_RedirectURI_Generation(t *testing.T) {
 		"scope":         "bazz",
 	})
 
-	m.startFlow = func(cfg Config, w http.ResponseWriter) {
+	m.startFlow = func(cfg Config, w http.ResponseWriter) error {
 		startFlowReceivedConfig = cfg
+		return nil
 	}
 
 	callURL := "http://example.com/login/github"

--- a/oauth2/oauth.go
+++ b/oauth2/oauth.go
@@ -72,7 +72,7 @@ func StartFlow(cfg Config, w http.ResponseWriter) error {
 	values.Set("response_type", "code")
 
 	// set and store the state param
-	state, err := randStringBytes(15)
+	state, err := randStringBytes(32)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
loginsrv currently uses `math/rand` with the service start time as a seed to generate oauth2 states and other secrets. This is of course an security issue and hence `math/rand` gets replaced with `crypto/rand` which [utilizes better sources of randomness](https://golang.org/pkg/crypto/rand/#pkg-variables).

Further this PR increases both the length of the default jwt secret to 2*64 byte and the length of the oauth2 state secret to 2*32 byte to avoid possible brute force attacks. (fixes #149)