### PR TITLE
Rename tip to master in travis build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ language: go
 go:
   - "1.12"
   - "1.13"
-  - tip
+  - master
 
 # Allow builds from tip to fail - they might be in an unstable state
 jobs:
   allow_failures:
-    - go: tip
+    - go: master
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
Travis favors master now, and [gimme](https://github.com/travis-ci/gimme) even fails in some cases with "tip".