### PR TITLE
Move binary build into dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine3.10 as builder
+FROM golang:1.13-alpine3.11 as builder
 RUN apk --update --no-cache add g++
 
 WORKDIR /build
@@ -15,7 +15,7 @@ RUN go build -a --ldflags '-linkmode external -extldflags "-static"' .
 
 # ----------
 
-FROM alpine:3.10
+FROM alpine:3.11
 RUN apk --update --no-cache add ca-certificates \
     && addgroup -S loginsrv && adduser -S -g loginsrv loginsrv
 USER loginsrv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,27 @@
-FROM alpine
+FROM golang:1.13-alpine3.10 as builder
+RUN apk --update --no-cache add g++
+
+WORKDIR /build
+
+# Cache dependencies
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+# Copy code
+COPY . .
+
+RUN go build -a --ldflags '-linkmode external -extldflags "-static"' .
+
+# ----------
+
+FROM alpine:3.10
 RUN apk --update --no-cache add ca-certificates \
     && addgroup -S loginsrv && adduser -S -g loginsrv loginsrv
 USER loginsrv
+
 ENV LOGINSRV_HOST=0.0.0.0 LOGINSRV_PORT=8080
-COPY loginsrv /
 ENTRYPOINT ["/loginsrv"]
 EXPOSE 8080
+
+COPY --from=builder /build/loginsrv /

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-GOOS=linux go build -a --ldflags '-linkmode external -extldflags "-static"' . ;
 docker build -t tarent/loginsrv . ;
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" ;
 docker push tarent/loginsrv ;


### PR DESCRIPTION
As stated in #154, the binary is currently build against glibc, and deployed in a musl image. This PR fixes this, by moving the build into the Dockerfile.

I tried to take care to not alter the resulting image too much.