### PR TITLE
Fix #165 by using Authorization header instead

### DIFF
--- a/oauth2/github.go
+++ b/oauth2/github.go
@@ -33,8 +33,7 @@ var providerGithub = Provider{
 		url := githubAPI + "/user"
 		req, _ := http.NewRequest("GET", url, nil)
 		req.Header.Set("Authorization", "token " + token.AccessToken)
-		client := &http.Client{}
-		resp, err := client.Do(req)
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return model.UserInfo{}, "", err
 		}

--- a/oauth2/github.go
+++ b/oauth2/github.go
@@ -30,8 +30,11 @@ var providerGithub = Provider{
 	TokenURL: "https://github.com/login/oauth/access_token",
 	GetUserInfo: func(token TokenInfo) (model.UserInfo, string, error) {
 		gu := GithubUser{}
-		url := fmt.Sprintf("%v/user?access_token=%v", githubAPI, token.AccessToken)
-		resp, err := http.Get(url)
+		url := githubAPI + "/user"
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Set("Authorization", "token " + token.AccessToken)
+		client := &http.Client{}
+		resp, err := client.Do(req)
 		if err != nil {
 			return model.UserInfo{}, "", err
 		}

--- a/oauth2/github_test.go
+++ b/oauth2/github_test.go
@@ -42,7 +42,7 @@ var githubTestUserResponse = `{
 
 func Test_Github_getUserInfo(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Equal(t, "secret", r.FormValue("access_token"))
+		Equal(t, "token secret", r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Write([]byte(githubTestUserResponse))
 	}))


### PR DESCRIPTION
Fixes #165 by using the Authorization header instead of the `access_token` query param.

To test:

1. Create a new GitHub OAuth App at https://github.com/settings/developers

2. Run a server with this new version first, and login with GitHub. Verify that you did not get a deprecation notice email

3. Run the current master server, and login with GitHub. You'll see you did get a deprecation notice for the current server