### PR TITLE
Implement support for virtual hosts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,5 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/tarent/lib-compose v0.0.0-20170829113806-69430f91d1d6
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 )

--- a/go.sum
+++ b/go.sum
@@ -128,3 +128,5 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/login/config.go
+++ b/login/config.go
@@ -88,6 +88,9 @@ type Config struct {
 	UserEndpoint           string
 	UserEndpointToken      string
 	UserEndpointTimeout    time.Duration
+	HealthCheckPath        string
+	ConfigFile             string
+	VHosts                 []VirtualHost
 }
 
 // Options is the configuration structure for oauth and backend provider
@@ -161,6 +164,8 @@ func (c *Config) ConfigureFlagSet(f *flag.FlagSet) {
 	f.StringVar(&c.UserEndpoint, "user-endpoint", c.UserEndpoint, "URL of an endpoint providing user specific data for the tokens")
 	f.StringVar(&c.UserEndpointToken, "user-endpoint-token", c.UserEndpointToken, "Authentication token used when communicating with the user endpoint")
 	f.DurationVar(&c.UserEndpointTimeout, "user-endpoint-timeout", c.UserEndpointTimeout, "Timeout used when communicating with the user endpoint")
+	f.StringVar(&c.HealthCheckPath, "health-check-path", c.HealthCheckPath, "When set, respond with 200 to a GET request on this (absolute) path")
+	f.StringVar(&c.ConfigFile, "config", c.ConfigFile, "YAML configuration file")
 
 	// the -backends is deprecated, but we support it for backwards compatibility
 	deprecatedBackends := setFunc(func(optsKvList string) error {
@@ -232,6 +237,9 @@ func readConfig(f *flag.FlagSet, args []string) (*Config, error) {
 		return nil, err
 	}
 
+	if err := parseConfigFile(config); err != nil {
+		return nil, err
+	}
 	return config, err
 }
 

--- a/login/config_file.go
+++ b/login/config_file.go
@@ -1,0 +1,41 @@
+package login
+
+import (
+	"io/ioutil"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// yamlConfig holds the top level configuration data.
+type yamlConfig struct {
+	LoginPath       string        `yaml:"login-path"`
+	HealthCheckPath string        `yaml:"health-check-path"`
+	VHosts          []VirtualHost `yaml:"vhosts"`
+}
+
+func parseConfigData(config *Config, data []byte) error {
+	var configdata yamlConfig
+	if err := yaml.Unmarshal(data, &configdata); err != nil {
+		return err
+	}
+
+	if configdata.LoginPath != "" {
+		config.LoginPath = configdata.LoginPath
+	}
+	if configdata.HealthCheckPath != "" {
+		config.HealthCheckPath = configdata.HealthCheckPath
+	}
+	config.VHosts = configdata.VHosts
+	return nil
+}
+
+func parseConfigFile(config *Config) error {
+	if config.ConfigFile == "" {
+		return nil
+	}
+	b, err := ioutil.ReadFile(config.ConfigFile)
+	if err != nil {
+		return err
+	}
+	return parseConfigData(config, b)
+}

--- a/login/config_file_test.go
+++ b/login/config_file_test.go
@@ -1,0 +1,15 @@
+package login
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigFileSimple(t *testing.T) {
+	config := &Config{
+		ConfigFile: "testdata/test1.yaml",
+	}
+	err := parseConfigFile(config)
+	assert.NoError(t, err)
+}

--- a/login/testdata/test1.yaml
+++ b/login/testdata/test1.yaml
@@ -1,0 +1,18 @@
+login-path: /auth/login
+health-check-path: /
+vhosts:
+  - name: foo
+    hostname: foohost
+    cookie-domain: foo.domain.com
+    backends:
+      - name: simple
+        bob: secret
+    oauth:
+      - provider: google
+        client_id: foo@bar.com
+        client_secret: deadbeef
+    template: foo.html.tmpl
+    users:
+      - origin: simple
+        claims:
+          project: foo

--- a/login/user_claims_file.go
+++ b/login/user_claims_file.go
@@ -6,7 +6,7 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 	"github.com/tarent/loginsrv/model"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 type userFileEntry struct {

--- a/login/vhost.go
+++ b/login/vhost.go
@@ -1,0 +1,140 @@
+package login
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/tarent/loginsrv/oauth2"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// OAuthConfig contains the parsed oauth configuration
+type OAuthConfig struct {
+	Provider     string `yaml:"provider"`
+	ClientID     string `yaml:"client-id"`
+	ClientSecret string `yaml:"client-secret"`
+	RedirectURI  string `yaml:"redirect-uri"`
+	Score        string `yaml:"scope"`
+}
+
+// Convert options to a map
+func (o *OAuthConfig) Convert() map[string]string {
+	values := make(map[string]string)
+	typ := reflect.TypeOf(*o)
+	vtype := reflect.ValueOf(*o)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		k := strings.Split(field.Tag.Get("yaml"), ",")[0]
+		if k == "provider" {
+			continue
+		}
+		k = strings.Replace(k, "-", "_", -1)
+		v := vtype.Field(i).String()
+		if v == "" {
+			continue
+		}
+		values[k] = v
+	}
+	return values
+}
+
+// VHostConfig contains per virtual host configuration
+type VHostConfig struct {
+	// Configuration object name (mandatory)
+	Name string `yaml:"name"`
+	// Hostname of the virtual host (defaults to Name)
+	Hostname string `yaml:"hostname"`
+
+	CookieDomain string `yaml:"cookie-domain"`
+	Template     string `yaml:"template"`
+
+	BackendConfigs []yaml.Node     `yaml:"backends"`
+	OAuthConfigs   []OAuthConfig   `yaml:"oauth"`
+	Users          []userFileEntry `yaml:"users"`
+}
+
+// VirtualHost contains the state for a virtual host.
+type VirtualHost struct {
+	Config   VHostConfig
+	Backends []Backend
+}
+
+func (v *VirtualHost) makeHandler(globalConfig *Config) (*Handler, error) {
+	claims := &userClaimsFile{
+		userFileEntries: v.Config.Users,
+	}
+	vhostOauth := oauth2.NewManager()
+	for _, authConfig := range v.Config.OAuthConfigs {
+		opts := authConfig.Convert()
+		if err := vhostOauth.AddConfig(authConfig.Provider, opts); err != nil {
+			return nil, err
+		}
+	}
+
+	config := *globalConfig
+	if v.Config.CookieDomain != "" {
+		config.CookieDomain = v.Config.CookieDomain
+	}
+	if v.Config.Template != "" {
+		config.Template = v.Config.Template
+	}
+
+	return &Handler{
+		backends:   v.Backends,
+		config:     &config,
+		userClaims: claims.Claims,
+		oauth:      vhostOauth,
+	}, nil
+}
+
+func decodeBackend(node *yaml.Node) (Backend, error) {
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("Unexpected yaml object type for backend")
+	}
+
+	opts := make(map[string]string, len(node.Content)/2)
+	var key string
+	for i, subnode := range node.Content {
+		if i&1 == 0 {
+			key = subnode.Value
+			continue
+		}
+		opts[key] = subnode.Value
+	}
+
+	p, exists := GetProvider(opts["name"])
+	if !exists {
+		return nil, fmt.Errorf("Undefined backend: %s", opts["name"])
+	}
+	delete(opts, "name")
+	return p(opts)
+}
+
+// UnmarshalYAML decodes the vhost config object
+func (v *VirtualHost) UnmarshalYAML(node *yaml.Node) error {
+	if err := node.Decode(&v.Config); err != nil {
+		return err
+	}
+	if v.Config.Name == "" {
+		return fmt.Errorf("vhost object must define name attribute")
+	}
+
+	for _, node := range v.Config.BackendConfigs {
+		backend, err := decodeBackend(&node)
+		if err != nil {
+			return err
+		}
+		v.Backends = append(v.Backends, backend)
+	}
+	for _, oauthConfig := range v.Config.OAuthConfigs {
+		if _, exists := oauth2.GetProvider(oauthConfig.Provider); !exists {
+			return fmt.Errorf("Unknown oauth2 provider: %s", oauthConfig.Provider)
+		}
+	}
+
+	if v.Config.Hostname == "" {
+		v.Config.Hostname = v.Config.Name
+	}
+	return nil
+}

--- a/login/vhost_test.go
+++ b/login/vhost_test.go
@@ -1,0 +1,114 @@
+package login
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tarent/loginsrv/model"
+	"github.com/tarent/loginsrv/oauth2"
+)
+
+func TestVHostSelection(t *testing.T) {
+	testCases := []struct {
+		hostname string
+		username string
+		password string
+		expect   bool
+	}{
+		{"default.domain.org", "bob", "secret", true},
+		{"default.domain.org", "bob", "admin", false},
+		{"foo.domain.org", "bob", "thebuilder", true},
+		{"foo.domain.org", "bob", "secret", false},
+		{"bar.domain.org", "bob", "thebuilder", false},
+		{"bar.domain.org", "bob", "admin", true},
+	}
+
+	var configFile = `
+    vhosts:
+      - name: foo
+        backends:
+          - name: simple
+            bob: thebuilder
+      - name: bar
+        backends:
+           - name: simple
+             bob: admin
+    `
+
+	config := DefaultConfig()
+	config.Backends = Options{
+		SimpleProviderName: map[string]string{
+			"bob": "secret",
+		},
+	}
+	require.NoError(t, parseConfigData(config, []byte(configFile)))
+
+	handler, err := NewHandler(config)
+	require.NoError(t, err)
+
+	for i, testCase := range testCases {
+		data := struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}{testCase.username, testCase.password}
+		body, err := json.Marshal(&data)
+		assert.NoError(t, err)
+		req, err := http.NewRequest(http.MethodPost, config.LoginPath, bytes.NewReader(body))
+		req.URL.Host = testCase.hostname
+		req.Header.Set("Content-type", "application/json")
+		require.NoError(t, err)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		assert.Equal(t, testCase.expect, rec.Code == http.StatusOK, fmt.Sprintf("test case %d", i))
+	}
+}
+
+func TestVHostOAuth(t *testing.T) {
+	var configFile = `
+    vhosts:
+      - name: foo
+        oauth:
+          - provider: mock-vhost-oauth
+            client-id: me@example.com
+            client-secret: secrect
+    `
+
+	config := DefaultConfig()
+	require.NoError(t, parseConfigData(config, []byte(configFile)))
+	handler, err := NewHandler(config)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, config.LoginPath+"/mock-vhost-oauth", nil)
+	req.URL.Host = "foo.example.org"
+	req.Header.Set("Content-type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusFound, rec.Code)
+	loc, err := url.Parse(rec.Header().Get("Location"))
+	assert.NoError(t, err)
+	assert.Equal(t, "mock-auth-service", loc.Hostname())
+}
+
+func makeMockVHostOAuthProvier() oauth2.Provider {
+	return oauth2.Provider{
+		Name:     "mock-vhost-oauth",
+		AuthURL:  "https://mock-auth-service/auth",
+		TokenURL: "https://mock-auth-service/token",
+		GetUserInfo: func(token oauth2.TokenInfo) (model.UserInfo, string, error) {
+			return model.UserInfo{Sub: "marvin"}, "", nil
+		},
+	}
+}
+
+func TestMain(m *testing.M) {
+	oauth2.RegisterProvider(makeMockVHostOAuthProvier())
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
This PR adds support for a new yaml configuration file which allows different auth backend usage based on the HOST request header field.

It also adds an health-check option that can be used to specify a path where the server responds with an 200 OK. This is used when the load balancer checks the health of the backend.

Please let me know whether you would be interested in accepting this functionality.